### PR TITLE
pinning tagged and internal dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,8 @@
 %% -*- erlang -*-
 {erl_opts, [debug_info]}.
 {deps, [
-        {edown, ".*", {git, "https://github.com/uwiger/edown.git", "HEAD"}},
-        {gen_leader, ".*",
-	 {git, "https://github.com/garret-smith/gen_leader_revival.git", "HEAD"}}
+        {edown, ".*", {git, "https://github.com/basho/edown.git", {tag, "1.5"}}},
+        {gen_leader, ".*", {git, "https://github.com/basho/gen_leader_revival.git", {tag, "basho1"}}}
        ]}.
 {dialyzer_opts, [{warnings, [no_unused,
                              no_improper_lists, no_fun_app, no_match,


### PR DESCRIPTION
This PR allows Riak to build against a tagged (if not released) dependency version.